### PR TITLE
Implement and use FirewallInterface.getPolicyByHostname.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "droid/droid-model": "~1.0",
+        "droid/droid-model": "~1.3",
         "symfony/console": "~2.7"
     },
     "require-dev": {

--- a/src/Generator/UfwGenerator.php
+++ b/src/Generator/UfwGenerator.php
@@ -25,7 +25,7 @@ class UfwGenerator
 
         $o[] = 'ufw --force reset';
 
-        foreach ($this->firewall->getPolicy() as $direction => $action) {
+        foreach ($this->firewall->getPolicyByHostname($hostname) as $direction => $action) {
             $o[] = sprintf('ufw default %s %s', $action, $direction);
         }
 

--- a/src/Model/UfwFirewall.php
+++ b/src/Model/UfwFirewall.php
@@ -41,19 +41,27 @@ class UfwFirewall implements FirewallInterface
     }
 
     /**
-     * Get the default firewall policy, as a map of directions to actions.
+     * Get the default firewall policy for the named Host, as a map of
+     * directions to actions.
      *
      * The policy returned will be the "standard" policy (see standardPolicy)
      * merged with a policy obtained from Droid's Firewall.
      *
+     * @param string $name Name of a Host
+     *
      * @return array
      */
-    public function getPolicy()
+    public function getPolicyByHostname($name)
     {
         return array_merge(
             $this->standardPolicy(),
-            $this->firewall->getPolicy()
+            $this->firewall->getPolicyByHostname($name)
         );
+    }
+
+    public function getPolicy()
+    {
+        return $this->standardPolicy();
     }
 
     /**

--- a/test/Generator/UfwGeneratorTest.php
+++ b/test/Generator/UfwGeneratorTest.php
@@ -70,7 +70,7 @@ class UfwGeneratorTest extends \PHPUnit_Framework_TestCase
         ;
         $this
             ->firewall
-            ->method('getPolicy')
+            ->method('getPolicyByHostname')
             ->willReturn(array('incoming' => 'deny'))
         ;
 

--- a/test/Model/UfwFirewallTest.php
+++ b/test/Model/UfwFirewallTest.php
@@ -26,11 +26,11 @@ class UfwFirewallTest extends \PHPUnit_Framework_TestCase
         $this
             ->baseFirewall
             ->expects($this->once())
-            ->method('getPolicy')
+            ->method('getPolicyByHostname')
             ->willReturn(array())
         ;
 
-        $policy = $this->firewall->getPolicy();
+        $policy = $this->firewall->getPolicyByHostname('some-name');
 
         foreach (UfwFirewall::directions() as $direction) {
             $this->assertArrayHasKey(
@@ -58,13 +58,13 @@ class UfwFirewallTest extends \PHPUnit_Framework_TestCase
 
         $this
             ->baseFirewall
-            ->method('getPolicy')
+            ->method('getPolicyByHostname')
             ->willReturn($customPolicy)
         ;
 
         $this->assertSame(
             array_merge($defaultPolicy, $customPolicy),
-            $this->firewall->getPolicy()
+            $this->firewall->getPolicyByHostname('some-name')
         );
     }
 


### PR DESCRIPTION
The firewall policy can now be declared in Droid Inventory at the level of HostGroup and/or Host.
